### PR TITLE
Increase the token limit for anthropic

### DIFF
--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -5,7 +5,7 @@
 const puppeteer = require('puppeteer');
 
 (async () => {
-    const browser = await puppeteer.launch({executablePath: '/home/vishalds/.cache/puppeteer/chrome/linux-126.0.6478.126/chrome-linux64/chrome'});
+    const browser = await puppeteer.launch({executablePath: '/home/vishalds/.cache/puppeteer/chrome/linux-126.0.6478.182/chrome-linux64/chrome'});
     const page = await browser.newPage();
     await page.goto('file://' + process.argv[2]);
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -33,6 +33,7 @@ pub async fn proxy_anthropic(
     let anthropic_req = app_state.client.post("https://api.anthropic.com/v1/messages")
         .header("x-api-key", bearer_token)
         .header("anthropic-version", "2023-06-01")
+        .header("anthropic-beta", "max-tokens-3-5-sonnet-2024-07-15")
         .header("content-type", "application/json")
         .body(payload);
 


### PR DESCRIPTION
Currently, Claude's performance is quite limited. This is in relation with [#4](https://github.com/zitefy/portal/issues/4) in the portal. Anthropic informs that

> max_tokens: 6000 > 4096, which is the maximum allowed number of output tokens for claude-3-5-sonnet-20240620. To access up to 8192 output tokens, specify the `anthropic-beta: max-tokens-3-5-sonnet-2024-07-15` header.

This PR modifies the `proxy_anthropic()` method to include the header.