### PR TITLE
Added CORS headers to `proxy_anthropic`

### DIFF
--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -5,7 +5,7 @@
 const puppeteer = require('puppeteer');
 
 (async () => {
-    const browser = await puppeteer.launch({executablePath: '/home/vishalds/.cache/puppeteer/chrome/linux-126.0.6478.126/chrome-linux64/chrome'});
+    const browser = await puppeteer.launch({executablePath: '/home/vishalds/.cache/puppeteer/chrome/linux-126.0.6478.182/chrome-linux64/chrome'});
     const page = await browser.newPage();
     await page.goto('file://' + process.argv[2]);
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -41,7 +41,11 @@ pub async fn proxy_anthropic(
         Ok(response) => {
             let status = response.status();
             let body = response.bytes().await.unwrap_or_default();
-            HttpResponse::build(status).body(body)
+            HttpResponse::build(status)
+                .header("Access-Control-Allow-Origin", "https://zitefy.com")
+                .header("Access-Control-Allow-Methods", "POST, OPTIONS")
+                .header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+                .body(body)
         },
         Err(e) => HttpResponse::InternalServerError().body(format!("Error: {}", e)),
     }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -33,6 +33,7 @@ pub async fn proxy_anthropic(
     let anthropic_req = app_state.client.post("https://api.anthropic.com/v1/messages")
         .header("x-api-key", bearer_token)
         .header("anthropic-version", "2023-06-01")
+        .header("anthropic-beta", "max-tokens-3-5-sonnet-2024-07-15")
         .header("content-type", "application/json")
         .body(payload);
 


### PR DESCRIPTION
After #7, the server seems to exhibits a weird behavior where it doesn't supply cors headers to the portal. Hence, this PR explicitly adds the CORS headers for zitefy.com to the `proxy_anthropic()` method.