### PR TITLE
Temporary fix for #4

### DIFF
--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -3,19 +3,43 @@
     During initial setup, run bun run puppeteer browsers install chrome, and copy the executable path to line 8
 */
 const puppeteer = require('puppeteer');
+const fs = require('fs');
 
 (async () => {
-    const browser = await puppeteer.launch({executablePath: '/home/vishalds/.cache/puppeteer/chrome/linux-126.0.6478.182/chrome-linux64/chrome'});
-    const page = await browser.newPage();
-    await page.goto('file://' + process.argv[2]);
+    try {
+        const browser = await puppeteer.launch({
+            executablePath: '/home/vishalds/.cache/puppeteer/chrome/linux-126.0.6478.182/chrome-linux64/chrome',
+            args: ['--no-sandbox', '--disable-setuid-sandbox']
+        });
 
-    // Mobile screenshot
-    await page.setViewport({ width: 412, height: 915 });
-    await page.screenshot({ path: process.argv[3] });
+        const page = await browser.newPage();
+        await page.setRequestInterception(true);
 
-    // Desktop screenshot
-    await page.setViewport({ width: 1280, height: 800 });
-    await page.screenshot({ path: process.argv[4] });
+        // Intercept requests to our own API & block them
+        // this is a temporary fix, has to be mitigated completely asap
+        page.on('request', (request) => {
+            if (request.url().includes('api.zitefy.com')) {
+                request.abort();
+            } else {
+                request.continue();
+            }
+        });
 
-    await browser.close();
+        await page.goto('file://' + process.argv[2], { 
+            waitUntil: 'networkidle0', 
+            timeout: 60000
+        });
+
+        await page.setViewport({ width: 412, height: 915 });
+        await page.screenshot({ path: process.argv[3] });
+
+        await page.setViewport({ width: 1280, height: 800 });
+        await page.screenshot({ path: process.argv[4] });
+
+        await browser.close();
+
+    } catch (error) {
+        fs.writeFileSync('screenshot_error.log', error.toString());
+        process.exit(1);
+    }
 })();


### PR DESCRIPTION
Right now, puppeteer times out waiting for any assets to load from within the same server. This seems a bit tricky to solve right now. So, this PR temporarily fixes #4 by disabling loading any assets from our own endpoints for the previews. The resource will still be available in your final site, just not in the preview. The timeout for puppeteer has been set to 60s as well.